### PR TITLE
Global metrics and historical data

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,14 +4,14 @@ This is the Celpax's PHP DailyPulse Client API. Note that:
 
 It matches pretty much the [NodeJS API](https://github.com/celpax/dailypulse) Client.
 
-##API Client Architecture
+##  API Client Architecture
 
 - The client connects to the server using JSON/REST web services. 
 - All requests run over HTTPS and the URI is signed with a timestamped cryptographic token implemented using HMAC-SHA512.
 - The client uses internally [Guzzle](http://guzzle.readthedocs.org) to send the REST requests and parse the received JSON.
 - A Response object encapsulates the downloaded JSON, HTTP Status and exception information from either client or server side.
 
-##Instalation
+## Installation
 
 The PHP DailyPulse client is distributed as a [composer package](https://packagist.org/packages/celpax/dailypulse).
 
@@ -77,7 +77,12 @@ You can retrieve the latest calculated Mood KPI for a give site as follows:
 
 Note that in some cases the Mood KPI cannot be calculated (for example during rollout) and will be returned as null. A date member will also be included indicating when the Mood KPI was last updated.
 
+Alternatively, you can retrieve the latest calculated global Mood KPI of all the sites of the account as follows:
 
+```php
+    $response=$dailyPulseClient->getGlobalMoodKPI();
+    $green=$response->json()['green'];
+```
 ## Historical Mood KPI
 
 You can retrieve the historical calculated Mood KPI for a given site and the number of days to fetch since today as follows:
@@ -89,6 +94,12 @@ You can retrieve the historical calculated Mood KPI for a given site and the num
 
 The maximum number of allowed days to be fetched can be configured in the Celpax Dashboard console. You need administrator privileges for accessing to the configuration section. 
 
+Alternatively you can retrieve the historical calculated global mood KPI of all the sites of the account as follows:
+
+```php
+   $response=$dailyPulseClient->getHistoricalGlobalMoodKPI($number_of_days);
+   $green=$response->json()[0]['green'];
+```
 
 ## Pulses in a Typical Day
 
@@ -105,6 +116,14 @@ You can get it in a similar way by doing:
 ```
 A date member will also be returned indicating when the pulses per typical day was last updated.
 
+Alternatively, you can retrieve the global pulses in a typical day of all the sites of the account as follows:
+ 
+```php
+    $response=$dailyPulseClient->getGlobalPulsesPerTypicalDay();
+    $pulses=$response->json()['pulses'];
+});
+```
+
 ## Historical Pulses in a Typical Day
 
 You can retrieve the historical Pulses in a Typical day for a given site and the number of days to fetch since today as follows:
@@ -116,6 +135,11 @@ You can retrieve the historical Pulses in a Typical day for a given site and the
 
 The maximum number of allowed days to be fetched can be configured in the Celpax Dashboard console. You need administrator privileges for accessing to the configuration section. 
 
+Alternatively, you can retrieve the historical global pulses per typical day of all the sites of the account as follows:
+```php
+    $response=$dailyPulseClient->getHistoricalGlobalPulsesPerTypicalDay($number_of_days);
+    $pulses=$response->json()[0]['pulses'];
+```
 
 ## User Interface Design
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -8,7 +8,7 @@ use GuzzleHttp\Exception\RequestException;
 class Client {
 
     const API_ENDPOINT="https://api.celpax.com";
-    const VERSION="1.0.11";
+    const VERSION="1.0.12";
     const ACCEPTS_VERSION="~1.0";
 
     const SIGNATURE_HEADER="X-Celpax-Signature";
@@ -73,16 +73,34 @@ class Client {
         return $this->get('/latest/mood/' . $site_id);
     }
 
+    public function getGlobalMoodKPI(){
+        return $this->get('/latest/mood');
+    }
+
     public function getPulsesPerTypicalDay($site_id){
         return $this->get('/latest/pulsesperday/' . $site_id);
     }
 
+    public function getGlobalPulsesPerTypicalDay(){
+        return $this->get('/latest/pulsesperday');
+    }
+
     public function getHistoricalMoodKPI($site_id, $number_of_days){
-        return $this->get('/historical/mood/' . $site_id . '/' . $number_of_days);
+        return $this->get('/historical/mood/' . $number_of_days . '/' . $site_id);
+
+    }
+
+    public function getHistoricalGlobalMoodKPI($number_of_days){
+        return $this->get('/historical/mood/' . $number_of_days );
+
     }
 
     public function getHistoricalPulsesPerTypicalDay($site_id, $number_of_days){
-        return $this->get('/historical/pulsesperday/' . $site_id . '/' . $number_of_days);
+        return $this->get('/historical/pulsesperday/' . $number_of_days . '/' . $site_id);
+    }
+
+    public function getHistoricalGlobalPulsesPerTypicalDay($number_of_days){
+        return $this->get('/historical/pulsesperday/' . $number_of_days );
     }
 
 

--- a/tests/APITest.php
+++ b/tests/APITest.php
@@ -32,6 +32,7 @@ class APITest extends \PHPUnit_Framework_TestCase {
         $this->assertFalse($response->isException());
         $this->assertEquals(200, $response->statusCode());
         $obj=$response->json();
+        echo 'testEchoService ' . json_encode($obj, JSON_PRETTY_PRINT)  .  PHP_EOL;
         $this->assertEquals('hello', $obj['msg']);
     }
 
@@ -40,6 +41,7 @@ class APITest extends \PHPUnit_Framework_TestCase {
         $this->assertFalse($response->isException());
         $this->assertEquals(200, $response->statusCode());
         $obj=$response->json();
+        echo 'testCompanySites ' . json_encode($obj, JSON_PRETTY_PRINT) .  PHP_EOL;
         $this->assertGreaterThan(0,count($obj));
         $site_id=$obj[0]['id'];
         return $site_id;
@@ -53,8 +55,29 @@ class APITest extends \PHPUnit_Framework_TestCase {
         $this->assertFalse($response->isException());
         $this->assertEquals(200, $response->statusCode());
         $obj=$response->json();
-
+        echo 'testSiteMoodKPI ' . json_encode($obj, JSON_PRETTY_PRINT)  .  PHP_EOL;
         // NOTE: the site might not have a mood KPI yet. in that
+        // Case red/green are NOT retunned.
+        $red=$obj['red'];
+        $green=$obj['green'];
+        $dateStr=$obj['date'];
+
+        // here is how to parse the date
+        $date=\DateTime::createFromFormat("Y-m-d",$dateStr);
+
+        $this->assertEquals(100-$red,$green);
+    }
+
+    /**
+     *
+     */
+    public function testGlobalMoodKPI(){
+        $response=$this->dailyPulseClient->getGlobalMoodKPI();
+        $this->assertFalse($response->isException());
+        $this->assertEquals(200, $response->statusCode());
+        $obj=$response->json();
+        echo 'testGlobalMoodKPI ' . json_encode($obj, JSON_PRETTY_PRINT)  .  PHP_EOL;
+        // NOTE: the global company might not have a mood KPI yet. in that
         // Case red/green are NOT retunned.
         $red=$obj['red'];
         $green=$obj['green'];
@@ -74,8 +97,31 @@ class APITest extends \PHPUnit_Framework_TestCase {
         $this->assertFalse($response->isException());
         $this->assertEquals(200, $response->statusCode());
         $obj=$response->json();
+        echo 'testPulsesPerTypicalDay ' . json_encode($obj, JSON_PRETTY_PRINT)  .  PHP_EOL;
 
         // NOTE: The site might not yet have a pulses per typical day KPI.
+        // in that case it is NOT returned.
+
+        $pulses=$obj['pulses'];
+        $dateStr=$obj['date'];
+
+        // here is how to parse the date
+        $date=\DateTime::createFromFormat("Y-m-d",$dateStr);
+
+        $this->assertGreaterThan(0,$pulses);
+    }
+
+    /**
+     *
+     */
+    public function testGlobalPulsesPerTypicalDay(){
+        $response=$this->dailyPulseClient->getGlobalPulsesPerTypicalDay();
+        $this->assertFalse($response->isException());
+        $this->assertEquals(200, $response->statusCode());
+        $obj=$response->json();
+        echo 'testGlobalPulsesPerTypicalDay ' . json_encode($obj, JSON_PRETTY_PRINT)  .  PHP_EOL;
+
+        // NOTE: The global company might not yet have a pulses per typical day KPI.
         // in that case it is NOT returned.
 
         $pulses=$obj['pulses'];
@@ -95,6 +141,29 @@ class APITest extends \PHPUnit_Framework_TestCase {
         $this->assertFalse($response->isException());
         $this->assertEquals(200, $response->statusCode());
         $obj=$response->json();
+        echo 'testHistoricalSiteMoodKPI ' . json_encode($obj, JSON_PRETTY_PRINT)  .  PHP_EOL;
+
+        // NOTE: the site might not have a mood KPI yet. in that
+        // Case red/green are NOT retunned.
+        $red=$obj[0]['red'];
+        $green=$obj[0]['green'];
+        $dateStr=$obj[0]['date'];
+
+        // here is how to parse the date
+        $date=\DateTime::createFromFormat("Y-m-d",$dateStr);
+
+        $this->assertEquals(100-$red,$green);
+    }
+
+    /**
+     *
+     */
+    public function testHistoricalGlobalMoodKPI(){
+        $response=$this->dailyPulseClient->getHistoricalGlobalMoodKPI($this-> number_of_days);
+        $this->assertFalse($response->isException());
+        $this->assertEquals(200, $response->statusCode());
+        $obj=$response->json();
+        echo 'testHistoricalGlobalMoodKPI ' . json_encode($obj, JSON_PRETTY_PRINT)  .  PHP_EOL;
 
         // NOTE: the site might not have a mood KPI yet. in that
         // Case red/green are NOT retunned.
@@ -117,6 +186,29 @@ class APITest extends \PHPUnit_Framework_TestCase {
         $this->assertFalse($response->isException());
         $this->assertEquals(200, $response->statusCode());
         $obj=$response->json();
+        echo 'testHistoricalPulsesPerTypicalDay ' . json_encode($obj, JSON_PRETTY_PRINT)  .  PHP_EOL;
+
+        // NOTE: The site might not yet have a pulses per typical day KPI.
+        // in that case it is NOT returned.
+
+        $pulses=$obj[0]['pulses'];
+        $dateStr=$obj[0]['date'];
+
+        // here is how to parse the date
+        $date=\DateTime::createFromFormat("Y-m-d",$dateStr);
+
+        $this->assertGreaterThan(0,$pulses);
+    }
+
+    /**
+     *
+     */
+    public function testHistoricalGlobalPulsesPerTypicalDay(){
+        $response=$this->dailyPulseClient->getHistoricalGlobalPulsesPerTypicalDay($this-> number_of_days);
+        $this->assertFalse($response->isException());
+        $this->assertEquals(200, $response->statusCode());
+        $obj=$response->json();
+        echo 'testHistoricalGlobalPulsesPerTypicalDay ' . json_encode($obj, JSON_PRETTY_PRINT)  .  PHP_EOL;
 
         // NOTE: The site might not yet have a pulses per typical day KPI.
         // in that case it is NOT returned.


### PR DESCRIPTION
implemented the calls for retrieving:
* the global Mood KPI for all the sites of the account.
* the global typical pulses per day of all the sites of the account.
* historical access to the Mood KPI and the typical pulses per day metrics for an specific site and for all the sites of the account.

All these features have been tested and documented.